### PR TITLE
Relax time upper-bound

### DIFF
--- a/bank-holidays-england.cabal
+++ b/bank-holidays-england.cabal
@@ -19,7 +19,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Data.Time.Calendar.BankHoliday.EnglandAndWales
   build-depends:       base >= 4.8 && < 5
-                     , time >= 1.5.0 && < 1.10
+                     , time >= 1.5.0 && < 1.13
                      , containers >= 0.5.0 && < 0.7
   hs-source-dirs:      src
   ghc-options: -Wall

--- a/bank-holidays-england.cabal
+++ b/bank-holidays-england.cabal
@@ -1,5 +1,5 @@
 name:                bank-holidays-england
-version:             0.2.0.5
+version:             0.2.0.6
 synopsis:            Calculation of bank holidays in England and Wales
 description:
   Calculation of bank holidays in England and Wales, using the rules that have


### PR DESCRIPTION
This is needed to re-admit the packing into stackage nightly.

I've checked and it builds fine with time-1.12.1, which is the latest on hackage